### PR TITLE
noConflict now resets root.jsonc correctly

### DIFF
--- a/jsonic.js
+++ b/jsonic.js
@@ -21,7 +21,7 @@ TODO: if number fails, assume it's just a string, might be an identifier of some
   }
 
   jsonic.noConflict = function() {
-    root.previous_jsonic = previous_jsonic;
+    root.jsonic = previous_jsonic;
     return self;
   }
 


### PR DESCRIPTION
I was reading your article on how to make node js modules work in the browser and ironically found this mistake ;)