### PR TITLE
Allow null/undefined this context

### DIFF
--- a/jsonic-head.js
+++ b/jsonic-head.js
@@ -6,7 +6,7 @@ TODO: if number fails, assume it's just a string, might be an identifier of some
 */
 
 ;(function() {
-  var root           = this
+  var root           = this || {}
   var previous_jsonic = root.jsonic
 
   var has_require = typeof require !== 'undefined'


### PR DESCRIPTION
In some module resolving environments, `this` can be null. In this case, jsonic crashes the build process. This change resolves that issue.
Just for reference: senecajs/seneca#436 should be fixed with this change