### PR TITLE
Add jsonic command line tool

### DIFF
--- a/bin/jsonic
+++ b/bin/jsonic
@@ -1,0 +1,3 @@
+#!env node
+
+require('../jsonic-cmd.js');

--- a/jsonic-cmd.js
+++ b/jsonic-cmd.js
@@ -1,4 +1,4 @@
-const jsonic = require('../jsonic');
+const jsonic = require('./jsonic');
 const json = process.argv.slice(2).join(' ');
 const obj = jsonic(json);
 console.log(JSON.stringify(obj));

--- a/jsonic-cmd.js
+++ b/jsonic-cmd.js
@@ -1,0 +1,4 @@
+const jsonic = require('../jsonic');
+const json = process.argv.slice(2).join(' ');
+const obj = jsonic(json);
+console.log(JSON.stringify(obj));

--- a/package.json
+++ b/package.json
@@ -31,6 +31,9 @@
     "jsonic-parser.js",
     "jsonic-parser.pegjs"
   ],
+  "bin": {
+    "jsonic": "bin/jsonic"
+  },
   "devDependencies": {
     "jasmine-node": "^3.0.0",
     "pegjs": "^0.10.0",


### PR DESCRIPTION
With these changes I can use jsonic from the command line to construct valid JSON.

```
➜ jsonic a:10, b:13
{"a":10,"b":13}

➜ jsonic a:10, b:13, extra: 'some text'
{"a":10,"b":13,"extra":"some text"}

➜ jsonic "a:10, b:13, extra: 'some text', nested: { data: 'text here', intval: 42 }"
{"a":10,"b":13,"extra":"some text","nested":{"data":"text here","intval":42}}
```

I can use this, for example, to feed into [http](https://github.com/httpie/httpie) like this:

```
➜ jsonic a:10, b:13, extra: 'some text' | http POST http://127.0.0.1:3000/api/commands
```



